### PR TITLE
Fix to match correct syntax

### DIFF
--- a/src/Form/Extension/ProductTypeExtension.php
+++ b/src/Form/Extension/ProductTypeExtension.php
@@ -30,7 +30,7 @@ final class ProductTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedTypes(): array
+    public static function getExtendedTypes(): iterable
     {
         return [ProductType::class];
     }


### PR DESCRIPTION
When upgrading to 1.7 We converted from getExtendedType to getExtendedTypes, but getExtendedTypes needs to be static 
https://symfony.com/blog/new-in-symfony-4-2-improved-form-type-extensions

`class ImageTypeExtension extends AbstractTypeExtension
{
    // ...

    public static function getExtendedTypes(): iterable
    {
        return [FileType::class];
    }
}
`