### PR TITLE
Fix typo in config file

### DIFF
--- a/src/Resources/config/routing/admin.yml
+++ b/src/Resources/config/routing/admin.yml
@@ -23,7 +23,7 @@ bitbag_product_bundle_admin_product_create_bundle:
                     name: bitbag_product_bundle_admin_product_create_bundle
 
 bitbag_product_bundle_admin_ajax_product_variants_by_phrase:
-    path: /ajax/product-variants/search-by-pharse
+    path: /ajax/product-variants/search-by-phrase
     methods: [GET]
     defaults:
         _controller: sylius.controller.product_variant:indexAction


### PR DESCRIPTION
Change `/ajax/product-variants/search-by-pharse` to `/ajax/product-variants/search-by-phrase`