### PR TITLE
Allow extending resources

### DIFF
--- a/src/Resources/config/doctrine/ProductBundle.orm.xml
+++ b/src/Resources/config/doctrine/ProductBundle.orm.xml
@@ -3,7 +3,7 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
 
-    <entity name="BitBag\SyliusProductBundlePlugin\Entity\ProductBundle" table="bitbag_product_bundle">
+    <mapped-superclass name="BitBag\SyliusProductBundlePlugin\Entity\ProductBundle" table="bitbag_product_bundle">
         <id name="id" type="integer">
             <generator strategy="AUTO"/>
         </id>
@@ -30,6 +30,6 @@
                 <cascade-all />
             </cascade>
         </one-to-many>
-    </entity>
+    </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Resources/config/doctrine/ProductBundleItem.orm.xml
+++ b/src/Resources/config/doctrine/ProductBundleItem.orm.xml
@@ -3,7 +3,7 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
 
-    <entity name="BitBag\SyliusProductBundlePlugin\Entity\ProductBundleItem" table="bitbag_product_bundle_item">
+    <mapped-superclass name="BitBag\SyliusProductBundlePlugin\Entity\ProductBundleItem" table="bitbag_product_bundle_item">
         <id name="id" type="integer">
             <generator strategy="AUTO"/>
         </id>
@@ -24,6 +24,6 @@
         <many-to-one field="productBundle" target-entity="BitBag\SyliusProductBundlePlugin\Entity\ProductBundleInterface" inversed-by="productBundleItems">
             <join-column name="product_bundle_id" referenced-column-name="id" nullable="false" />
         </many-to-one>
-    </entity>
+    </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Resources/config/doctrine/ProductBundleOrderItem.orm.xml
+++ b/src/Resources/config/doctrine/ProductBundleOrderItem.orm.xml
@@ -3,7 +3,7 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
 
-    <entity name="BitBag\SyliusProductBundlePlugin\Entity\ProductBundleOrderItem" table="bitbag_product_bundle_order_item">
+    <mapped-superclass name="BitBag\SyliusProductBundlePlugin\Entity\ProductBundleOrderItem" table="bitbag_product_bundle_order_item">
         <id name="id" type="integer">
             <generator strategy="AUTO"/>
         </id>
@@ -31,6 +31,6 @@
         <many-to-one field="productBundleItem" target-entity="BitBag\SyliusProductBundlePlugin\Entity\ProductBundleItemInterface">
             <join-column name="product_bundle_item_id" referenced-column-name="id" nullable="false"/>
         </many-to-one>
-    </entity>
+    </mapped-superclass>
 
 </doctrine-mapping>


### PR DESCRIPTION
Allow to extends resources and avoid the "The table with name 'shop.bitbag_product_bundle' already exists." error during doctrine:migrations:diff command