### PR TITLE
Add German translations in Product Bundle Plugin

### DIFF
--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,0 +1,8 @@
+bitbag_sylius_product_bundle:
+    ui:
+        bundle: 'Bundle'
+        product_variant: 'Produktvariante'
+        quantity: 'Menge'
+        delete: 'Löschen'
+        products_in_bundle: 'Produkte im Bundle'
+        is_packed_product: 'Ist gepacktes Produkt'

--- a/src/Resources/translations/validators.de.yml
+++ b/src/Resources/translations/validators.de.yml
@@ -1,0 +1,18 @@
+bitbag_sylius_product_bundle:
+    add_to_cart:
+        no_order_id_or_token: 'Weder die Bestell-ID noch das Token der Bestellung wurden bereitgestellt.'
+        cart_doesnt_exist: 'Warenkorb existiert nicht.'
+        product_bundle_doesnt_exist: 'Produktbundle mit der ID {{ id }} existiert nicht.'
+        product_disabled: 'Produkt mit dem Code {{ code }} ist nicht aktiviert.'
+        product_variant_disabled: 'Produktvariante mit dem Code {{ code }} ist nicht aktiviert.'
+        product_variant_insufficient_stock: 'Produktvariante mit dem Code {{ code }} hat nicht genügend Lagerbestand.'
+        product_doesnt_exist: 'Produkt existiert nicht.'
+        product_variant_doesnt_exist: 'Produkt {{ code }} hat keine Variante.'
+        product_doesnt_exist_in_channel: 'Der Kanal {{ channel }} hat kein Produkt mit dem Code {{ code }}.'
+    product:
+        not_a_bundle: 'Produkt muss ein Bundle sein.'
+    product_bundle_item:
+        product_variant:
+            not_blank: 'Produktvariante darf nicht leer sein.'
+        quantity:
+            not_blank: 'Menge darf nicht leer sein.'


### PR DESCRIPTION
This pull request introduces German translations for various messages in the BitBag Product Bundle Plugin. The translations improve user experience by providing clear and localized feedback for users interacting with product bundles.

Changes include:

- Added translations for messages related to product bundles and variants, ensuring users receive accurate notifications in German.

This update aims to enhance the usability of the plugin for German-speaking customers and maintain consistency with the existing localization efforts in the project.
